### PR TITLE
Add fitz stub to unit tests

### DIFF
--- a/tests/test_mcp.py
+++ b/tests/test_mcp.py
@@ -30,6 +30,7 @@ class _DummyPILImage:
 _make_module("PIL", {"Image": _DummyPILImage})
 
 # stub other modules imported at top of document_parser_refactored.py
+_make_module("fitz", {"Matrix": object, "Pixmap": object, "csRGB": object, "open": lambda *a, **k: None})
 _make_module("pdfplumber")
 _make_module("camelot", {"read_pdf": lambda *a, **k: []})
 _make_module("docx", {"Document": lambda f: None})


### PR DESCRIPTION
## Summary
- stub the fitz module in tests to prevent import failures when the real dependency is absent

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68e54163c078832ab0b864c9a1ed26bd