### PR TITLE
Add DashScope configuration defaults for VLM integration

### DIFF
--- a/config.py
+++ b/config.py
@@ -1,0 +1,4 @@
+DASHSCOPE_ENDPOINT = "https://dashscope.aliyuncs.com/compatible-mode/v1"
+DASHSCOPE_MODEL = "qwen2.5-vl"
+DASHSCOPE_API_KEY = "sk-e0a520f500c64b3199492e958545fffc"
+DASHSCOPE_PROVIDER = "dashscope"


### PR DESCRIPTION
## Summary
- add a dedicated `config.py` that hardcodes the DashScope endpoint, model, API key, and provider
- update `DocumentProcessor` to consume the shared configuration when VLM support is enabled and ensure MCP options toggle it

## Testing
- pytest *(fails: existing OCR expectations in tests/test_mcp.py were already unmet)*

------
https://chatgpt.com/codex/tasks/task_e_68e554cb44ac832aad84d4afee9cf1a2