### PR TITLE
Improve parse_document_url response shape and update docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,41 @@ Run unit tests with:
 pytest -q
 ```
 
+## Manual Testing with the Sample Report PDF
+
+The repository includes a small client script (`test.py`) that exercises the `parse_document_url` MCP tool end-to-end. To reproduce the flow with the hosted sample report:
+
+1. Start the MCP server in one terminal:
+
+   ```bash
+   uv run python main.py
+   ```
+
+2. In a second terminal, call the tool through the client:
+
+   ```bash
+   uv run python test.py
+   ```
+
+   The client is preconfigured to fetch `https://sample-files.com/downloads/documents/pdf/sample-report.pdf` and will print the structured response payload returned by the tool.
+
+Example output (truncated for brevity):
+
+```
+Type: pdf
+Keys: ['type', 'filename', 'elapsed_seconds', 'summary', 'markdown']
+Elapsed seconds: 1.74
+Summary snippet: # Parse Result for sample-report.pdf
+
+- **Type:** PDF
+- **Elapsed Seconds:** 1.75
+
+### Warnings
+- camelot failed: module 'camelot' has no attribute 'read_pdf'
+```
+
+The server log will emit warnings like `Cannot set gray stroke color because /'P6' is an invalid float value`; these originate from PyMuPDF while rendering embedded images and can be safely ignored during local testing.
+
 ## Repository Structure
 
 - `main.py` – core parsers, OCR helpers, VLM client, and MCP wiring.

--- a/main.py
+++ b/main.py
@@ -1360,7 +1360,26 @@ if mcp:
 
         try:
             parsed = dp.parse(file_bytes, filename)
-            return build_markdown_report(parsed, filename=filename)
+            report = build_markdown_report(parsed, filename=filename)
+
+            if isinstance(parsed, dict):
+                elapsed = parsed.get("elapsed_seconds")
+                doc_type = parsed.get("type", "document")
+            else:
+                elapsed = None
+                doc_type = "document"
+
+            summary = report[:500]
+            if len(report) > 500:
+                summary = summary.rstrip() + "..."
+
+            return {
+                "type": doc_type,
+                "filename": filename,
+                "elapsed_seconds": elapsed,
+                "summary": summary,
+                "markdown": report,
+            }
         except ValueError as e:
             return {"error": str(e)}
         except Exception:


### PR DESCRIPTION
## Summary
- return a structured JSON payload from `parse_document_url` that includes a summary preview alongside the full markdown report
- update the sample MCP client to call the hosted sample PDF and parse the returned payload for easier inspection
- document the manual testing workflow and expected output for the sample report in the README

## Testing
- uv run python test.py

------
https://chatgpt.com/codex/tasks/task_e_68eb773e4198832a8742c7c984f4ebc0